### PR TITLE
adds Dockerfile and docker-compose.yml, remove host from serve in ghost.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.10
+
+WORKDIR /app
+
+COPY . .
+RUN pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 1337
+CMD ["python","-u","ghost.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "1.0"
+
+services:
+  ghost:
+    build:
+      dockerfile: Dockerfile
+    environment:
+      - SPECS
+      - PROVIDER
+      - OPENAI_MODEL
+      - OPENAI_API_KEY
+      - AZURE_MODEL
+      - AZURE_DEPLOYMENT_NAME
+      - AZURE_API_VERSION
+      - AZURE_API_BASE
+      - AZURE_API_KEY
+      - PALM_MODEL
+    ports:
+      - 1337:1337
+    volumes:
+      - ./:/app

--- a/ghost.py
+++ b/ghost.py
@@ -153,6 +153,7 @@ def run():
 
 if __name__ == '__main__':
     print("\033[93mGhost started. Press CTRL+C to quit.\033[0m")
-    webbrowser.open("http://127.0.0.1:1337")
-    serve(ghost, host='127.0.0.1', port=1337)
+    # webbrowser.open("http://127.0.0.1:1337")
+    # serve(ghost, host='127.0.0.1', port=1337)
+    serve(ghost, port=1337)
 


### PR DESCRIPTION
Dockerizes ghost app for the following reasons: 
1) requirements need not be downloaded locally
2) acts as additional safeguard for shell tool (limits damage shell command can do to docker container)

Local folder is also mounted to docker container so changes made (eg ghost creates a new file) will be reflected in local machine. 

To run, use command `docker compose up --build`. Ensure docker and docker compose are installed first.

