### PR TITLE
Adds /reset route and consolidates configuration

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -1,0 +1,137 @@
+import sys
+
+from langchain.memory import ConversationBufferMemory
+from langchain.agents import initialize_agent, AgentType
+from langchain.chat_models import AzureChatOpenAI, ChatVertexAI, ChatOpenAI
+from langchain.llms import OpenAI, AzureOpenAI, VertexAI
+
+from tools import get_tools
+from config import specs_file, retries, provider
+from config import provider_config as cfg
+
+
+class Agent:
+    agent = None
+    llm = None
+
+    # initialise the agent
+    def __init__(self):
+        print("\033[96mInitialising Ghost with the following specifications:\033[0m")
+
+        self.empty()
+        llm = None
+
+        # read the specifications from file
+        specs = ""
+        with open(specs_file, 'r') as file:
+            specs = file.read()
+        print(specs, "\nlength:", len(specs), "words")
+        print(f"\033[96mUsing {cfg.provider} \033[0m")
+
+        # OpenAI
+        if cfg.provider == "openai":
+            if cfg.model_name.startswith("gpt-4") or cfg.model_name.startswith("gpt-3.5"):
+                llm = ChatOpenAI(
+                    temperature=0.7,
+                    model_name=cfg.model_name,
+                    openai_api_key=cfg.api_key,
+                    max_retries=retries,
+                )
+            else:
+                llm = OpenAI(
+                    temperature=0.7,
+                    model_name=cfg.model_name,
+                    openai_api_key=cfg.api_key,
+                    max_retries=retries,
+                )
+
+        # Azure OpenAI
+        if cfg.provider == "azure":
+            if cfg.model_name.startswith("gpt-4") or cfg.model_name.startswith("gpt-3.5"):
+                llm = AzureChatOpenAI(
+                    temperature=0.7,
+                    openai_api_base=cfg.base_url,
+                    openai_api_version=cfg.api_version,
+                    model_name=cfg.model_name,
+                    deployment_name=cfg.deployment_name,
+                    openai_api_key=cfg.api_key,
+                    max_retries=retries,
+                    openai_api_type="azure",
+                )
+            else:
+                llm = AzureOpenAI(
+                    temperature=0.7,
+                    openai_api_base=cfg.base_url,
+                    openai_api_version=cfg.api_version,
+                    model_name=cfg.model_name,
+                    deployment_name=cfg.deployment_name,
+                    openai_api_key=cfg.api_key,
+                    max_retries=retries,
+                    openai_api_type="azure",
+                )
+
+        # Google Vertex AI (PaLM)
+        if cfg.provider == "palm":
+            if cfg.model_name == "chat-bison" or cfg.model_name == "codechat-bison":
+                llm = ChatVertexAI(
+                    temperature=0.7,
+                    model_name=cfg.model_name,
+                    location=cfg.location,
+                    max_output_tokens=1024,
+                )
+            else:
+                llm = VertexAI(
+                    temperature=0.7,
+                    model_name=cfg.model_name,
+                    location=cfg.location,
+                    max_output_tokens=1024,
+                )
+
+        if llm is None:
+            sys.exit("No valid LLM configured:" + provider)
+
+        self.llm = llm
+
+        print(f"\033[96mWith {self.llm.model_name}\033[0m")
+
+        FORMAT_INSTRUCTIONS = """Do not put any quotes in output response and To use a tool, please use the following format:
+
+        \```
+        Thought: Do I need to use a tool? Yes
+        Action: the action to take, should be one of [{tool_names}]
+        Action Input: the input to the action
+        Observation: the result of the action
+        \```
+
+        When you have a response to say to the Human, or if you do not need to use a tool, you MUST use the following format(the prefix of "Thought: " and "{ai_prefix}: " are must be included):
+
+        \```
+        Thought: Do I need to use a tool? No
+        {ai_prefix}: [your response here]
+        \```
+        do not create any triplet quotes single or double in the output,only create ASCII characters in output and no comments required
+        """
+
+        # initialise agent execute
+        self.agent = initialize_agent(
+            get_tools(),
+            self.llm,
+            agent=AgentType.CONVERSATIONAL_REACT_DESCRIPTION,
+            memory=ConversationBufferMemory(
+                memory_key="chat_history", return_messages=True),
+            agent_kwargs={"format_instructions": FORMAT_INSTRUCTIONS},
+            handle_parsing_errors="Check the output and correct it to make it conform.",
+            verbose=True)
+
+        self.agent.run(specs)
+
+    def run(self, data):
+        return self.agent.run(data)
+
+    def empty(self):
+        self.agent = None
+        self.llm = None
+
+    def reset(self):
+        print("\033[96mReset agent has been triggered\033[0m")
+        self.__init__()

--- a/config.py
+++ b/config.py
@@ -1,0 +1,90 @@
+import os
+from collections import namedtuple
+
+from dotenv import load_dotenv, find_dotenv
+
+
+def getOpenaiProviderConfig() -> dict:
+    OpenaiConfig = namedtuple(
+        'OpenaiConfig',
+        [
+            'provider',
+            'api_key',
+            'model_name',
+            'api_version',
+            'base_url',
+        ],
+    )
+    return OpenaiConfig(
+        provider='openai',
+        api_key=os.getenv('OPENAI_API_KEY'),
+        model_name=os.getenv('OPENAI_MODEL'),
+        api_version=os.getenv('OPENAI_API_VERSION'),
+        base_url=os.getenv('OPENAI_API_BASE'),
+    )
+
+
+def getAzureProviderConfig() -> dict:
+    AzureConfig = namedtuple(
+        'AzureConfig',
+        [
+            'provider',
+            'api_key',
+            'model_name',
+            'deployment_name',
+            'api_version',
+            'base_url',
+        ],
+    )
+    return AzureConfig(
+        provider='azure',
+        api_key=os.getenv('AZURE_API_KEY'),
+        model_name=os.getenv('AZURE_MODEL'),
+        deployment_name=os.getenv('AZURE_DEPLOYMENT_NAME'),
+        api_version=os.getenv('AZURE_API_VERSION'),
+        base_url=os.getenv('AZURE_API_BASE'),
+    )
+
+
+def getPalmProviderConfig() -> dict:
+    PalmConfig = namedtuple(
+        'PalmConfig',
+        [
+            'provider',
+            'model_name',
+            'location',
+        ]
+    )
+    return PalmConfig(
+        provider='palm',
+        model_name=os.getenv('PALM_MODEL') or 'chat-bison',
+        location=os.getenv('PALM_LOCATION') or 'us-central1',
+    )
+
+
+def getProviderConfig(provider_name: str) -> dict:
+    supported_providers = ('palm', 'azure', 'openai')
+
+    if not isinstance(provider_name, str):
+        raise TypeError("Input must be a string.")
+
+    if provider_name not in supported_providers:
+        raise ValueError(
+            f"Invalid input. Supported providers: {supported_providers}.")
+
+    match provider_name:
+        case "openai":
+            return getOpenaiProviderConfig()
+        case "azure":
+            return getAzureProviderConfig()
+        case "palm":
+            return getPalmProviderConfig()
+
+
+# Get configurations
+load_dotenv(find_dotenv())
+specs_file = os.getenv('SPECS') or 'specs.md'  # defaults to specs.md
+output_file = os.getenv('OUTPUT_FILE') or 'output.md'  # defaults to output.md
+retries = int(os.getenv('MAX_RETRIES', 3) or 3)  # defaults to 3
+provider = os.getenv('PROVIDER') or 'openai'  # defaults to openai
+provider_config = getProviderConfig(provider_name=provider)

--- a/ghost.py
+++ b/ghost.py
@@ -1,147 +1,34 @@
 import os
-import sys
 from flask import Flask, render_template, request, jsonify
-from dotenv import load_dotenv, find_dotenv
-from langchain.memory import ConversationBufferMemory
-from langchain.agents import initialize_agent, AgentType
-from tools import get_tools
-from langchain.chat_models import AzureChatOpenAI, ChatVertexAI, ChatOpenAI
-from langchain.llms import OpenAI, AzureOpenAI, VertexAI
 from waitress import serve
 import webbrowser
 from datetime import datetime
 
-from config import specs_file, output_file, retries, provider
+from agents import Agent
+from config import output_file, provider
 from config import provider_config as cfg
 
-# Initialize
-llm = None
 
 # get path for static files
-static_dir = os.path.join(os.path.dirname(__file__), 'static')  
-if not os.path.exists(static_dir): 
-    static_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'static')
+static_dir = os.path.join(os.path.dirname(__file__), 'static')
+if not os.path.exists(static_dir):
+    static_dir = os.path.join(os.path.dirname(
+        os.path.abspath(__file__)), 'static')
 
-# initialise the agent
-def initAgent():
-    global llm
-    print("\033[96mInitialising Ghost with the following specifications:\033[0m")
-    # read the specifications from file
-    specs = ""
-    with open(specs_file, 'r') as file:
-        specs = file.read()
-    print(specs, "\nlength:", len(specs), "words")
-    print(f"\033[96mUsing {cfg.provider} \033[0m")
-
-    # OpenAI
-    if cfg.provider == "openai":
-        if cfg.model_name.startswith("gpt-4") or cfg.model_name.startswith("gpt-3.5"):
-            llm = ChatOpenAI(
-                temperature=0.7,
-                model_name=cfg.model_name,
-                openai_api_key=cfg.api_key,
-                max_retries=retries,
-            )      
-        else:
-            llm = OpenAI(
-                temperature=0.7,
-                model_name=cfg.model_name,
-                openai_api_key=cfg.api_key,
-                max_retries=retries,
-            )      
-
-
-    # Azure OpenA
-    if cfg.provider == "azure":
-        if cfg.model_name.startswith("gpt-4") or cfg.model_name.startswith("gpt-3.5"):                       
-            llm = AzureChatOpenAI(
-                temperature=0.7,
-                openai_api_base=cfg.base_url,
-                openai_api_version=cfg.api_version,
-                model_name=cfg.model_name,
-                deployment_name=cfg.deployment_name,
-                openai_api_key=cfg.api_key,
-                max_retries=retries,
-                openai_api_type = "azure",
-            )   
-        else:
-            llm = AzureOpenAI(
-                temperature=0.7,
-                openai_api_base=cfg.base_url,
-                openai_api_version=cfg.api_version,
-                model_name=cfg.model_name,
-                deployment_name=cfg.deployment_name,
-                openai_api_key=cfg.api_key,
-                max_retries=retries,
-                openai_api_type = "azure",
-            )   
-
-    # Google Vertex AI (PaLM)
-    if cfg.provider == "palm":
-        if cfg.model_name == "chat-bison" or cfg.odel_name == "codechat-bison":
-            llm = ChatVertexAI(
-                temperature=0.7,
-                model_name=cfg.model_name,
-                location=cfg.location,
-                max_output_tokens=1024,
-            )
-        else:
-            llm = VertexAI(
-                temperature=0.7,
-                model_name=cfg.model_name,
-                location=cfg.location,
-                max_output_tokens=1024,
-            )
-
-    if llm == None:
-        sys.exit("No valid LLM configured:" + provider)  
-
-    print(f"\033[96mWith {llm.model_name}\033[0m") 
-
-
-    FORMAT_INSTRUCTIONS = """Do not put any quotes in output response and To use a tool, please use the following format:
-
-\```
-Thought: Do I need to use a tool? Yes
-Action: the action to take, should be one of [{tool_names}]
-Action Input: the input to the action
-Observation: the result of the action
-\```
-
-When you have a response to say to the Human, or if you do not need to use a tool, you MUST use the following format(the prefix of "Thought: " and "{ai_prefix}: " are must be included):
-
-\```
-Thought: Do I need to use a tool? No
-{ai_prefix}: [your response here]
-\```
-do not create any triplet quotes single or double in the output,only create ASCII characters in output and no comments required
-"""
-
-    # initialise agent execut
-    agent = initialize_agent(
-        get_tools(), 
-        llm, 
-        agent=AgentType.CONVERSATIONAL_REACT_DESCRIPTION,         
-        memory=ConversationBufferMemory(memory_key="chat_history", return_messages=True),
-        agent_kwargs={"format_instructions": FORMAT_INSTRUCTIONS},
-        handle_parsing_errors="Check the output and correct it to make it conform.",
-        verbose=True)
-
-    agent.run(specs)
-    return agent
 
 def save(prompt, response):
-     with open(output_file, 'a') as file:
-         file.write("# " + provider.upper() + " " + llm.model_name.upper() + 
-                    " <small>[" + datetime.now().strftime("%Y-%m-%d %H:%M:%S") + "]</small>" + 
-                    "\n## PROMPT\n" + prompt +
-                    "\n## RESPONSE\n" + response + 
-                    "\n\n")
+    with open(output_file, 'a') as file:
+        file.write("# " + provider.upper() + " " + cfg.model_name.upper() +
+                   " <small>[" + datetime.now().strftime("%Y-%m-%d %H:%M:%S") + "]</small>" +
+                   "\n## PROMPT\n" + prompt +
+                   "\n## RESPONSE\n" + response +
+                   "\n\n")
+
 
 # start server
 print("\033[96mStarting Ghost at http://127.0.0.1:1337\033[0m")
 ghost = Flask(__name__, static_folder=static_dir, template_folder=static_dir)
-agent = initAgent()
+agent = Agent()
 
 # server landing page
 @ghost.route('/')
@@ -152,14 +39,22 @@ def landing():
 @ghost.route('/run', methods=['POST'])
 def run():
     data = request.json
-    response = agent.run(data['input'])   
-    save(data['input'], response) 
+    response = agent.run(data['input'])
+    save(data['input'], response)
     return jsonify({'input': data['input'],
                     'response': response})
+
+# reset
+@ghost.route('/reset', methods=['POST'])
+def reset():
+    agent.reset()
+    return jsonify({
+        'response': 'Agent was reset',
+    })
+
 
 if __name__ == '__main__':
     print("\033[93mGhost started. Press CTRL+C to quit.\033[0m")
     # webbrowser.open("http://127.0.0.1:1337")
     # serve(ghost, host='127.0.0.1', port=1337)
     serve(ghost, port=1337)
-

--- a/ghost.py
+++ b/ghost.py
@@ -11,12 +11,10 @@ from waitress import serve
 import webbrowser
 from datetime import datetime
 
-# get configurations
-load_dotenv(find_dotenv())
-specs_file = os.getenv('SPECS') or 'specs.md' # defaults to specs.md
-provider = os.getenv('PROVIDER') or 'openai' # defaults to openai
-output_file = os.getenv('OUTPUT_FILE') or 'output.md' # defaults to output.md
-retries = int(os.getenv('MAX_RETRIES', 3) or 3) # defaults to 3
+from config import specs_file, output_file, retries, provider
+from config import provider_config as cfg
+
+# Initialize
 llm = None
 
 # get path for static files
@@ -33,77 +31,65 @@ def initAgent():
     with open(specs_file, 'r') as file:
         specs = file.read()
     print(specs, "\nlength:", len(specs), "words")
-    print(f"\033[96mUsing {provider} \033[0m")
+    print(f"\033[96mUsing {cfg.provider} \033[0m")
 
     # OpenAI
-    if provider == "openai":
-        api_key  = os.getenv('OPENAI_API_KEY')
-        model_name = os.getenv('OPENAI_MODEL')
-        api_version = os.getenv('OPENAI_API_VERSION')
-        base_url = os.getenv('OPENAI_API_BASE')        
-
-        if model_name.startswith("gpt-4") or model_name.startswith("gpt-3.5"):
+    if cfg.provider == "openai":
+        if cfg.model_name.startswith("gpt-4") or cfg.model_name.startswith("gpt-3.5"):
             llm = ChatOpenAI(
                 temperature=0.7,
-                model_name=model_name,
-                openai_api_key=api_key,
+                model_name=cfg.model_name,
+                openai_api_key=cfg.api_key,
                 max_retries=retries,
             )      
         else:
             llm = OpenAI(
                 temperature=0.7,
-                model_name=model_name,
-                openai_api_key=api_key,
+                model_name=cfg.model_name,
+                openai_api_key=cfg.api_key,
                 max_retries=retries,
             )      
 
 
     # Azure OpenA
-    if provider == "azure":
-        api_key  = os.getenv('AZURE_API_KEY')
-        model_name = os.getenv('AZURE_MODEL')
-        deployment_name = os.getenv('AZURE_DEPLOYMENT_NAME')
-        api_version = os.getenv('AZURE_API_VERSION')
-        base_url = os.getenv('AZURE_API_BASE')
-
-        if model_name.startswith("gpt-4") or model_name.startswith("gpt-3.5"):                       
+    if cfg.provider == "azure":
+        if cfg.model_name.startswith("gpt-4") or cfg.model_name.startswith("gpt-3.5"):                       
             llm = AzureChatOpenAI(
                 temperature=0.7,
-                openai_api_base=base_url,
-                openai_api_version=api_version,
-                model_name=model_name,
-                deployment_name=deployment_name,
-                openai_api_key=api_key,
+                openai_api_base=cfg.base_url,
+                openai_api_version=cfg.api_version,
+                model_name=cfg.model_name,
+                deployment_name=cfg.deployment_name,
+                openai_api_key=cfg.api_key,
                 max_retries=retries,
                 openai_api_type = "azure",
             )   
         else:
             llm = AzureOpenAI(
                 temperature=0.7,
-                openai_api_base=base_url,
-                openai_api_version=api_version,
-                model_name=model_name,
-                deployment_name=deployment_name,
-                openai_api_key=api_key,
+                openai_api_base=cfg.base_url,
+                openai_api_version=cfg.api_version,
+                model_name=cfg.model_name,
+                deployment_name=cfg.deployment_name,
+                openai_api_key=cfg.api_key,
                 max_retries=retries,
                 openai_api_type = "azure",
             )   
 
     # Google Vertex AI (PaLM)
-    if provider == "palm":
-        model_name = os.getenv('PALM_MODEL', 'chat-bison')
-        if model_name == "chat-bison" or model_name == "codechat-bison":
+    if cfg.provider == "palm":
+        if cfg.model_name == "chat-bison" or cfg.odel_name == "codechat-bison":
             llm = ChatVertexAI(
                 temperature=0.7,
-                model_name=model_name,
-                location=os.getenv('PALM_LOCATION', 'us-central1'),
+                model_name=cfg.model_name,
+                location=cfg.location,
                 max_output_tokens=1024,
             )
         else:
             llm = VertexAI(
                 temperature=0.7,
-                model_name=model_name,
-                location=os.getenv('PALM_LOCATION', 'us-central1'),
+                model_name=cfg.model_name,
+                location=cfg.location,
                 max_output_tokens=1024,
             )
 


### PR DESCRIPTION
# Changes

- Adds /reset route in server

Sometimes it is useful to reset the agent to start afresh. Currently, the only way to do so is to restart the server. This PR wraps agent related code into a class (in `agents.py`) to make it easier to manage state. A new server route `/reset` is added in server, but not yet in frontend. Help to add this in frontend is appreciated.

This feature might be useful in the future if there is a need to run multiple agents at the same time.

- Consolidates configuration

Environment configuration has be abstracted to `config.py`.

# Testing

1. Run ghost and go to browser
2. Tell agent a secret number - 42
3. Ask agent for secret number - it should respond 42
4. Open a terminal and `curl -X POST localhost:1337/reset` - this could take a few seconds
5. Ask agent for secret number - it should have forgotten