### PR TITLE
SerpApi: Adds tools config support and makes SerpApi optional

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,6 +4,21 @@ from collections import namedtuple
 from dotenv import load_dotenv, find_dotenv
 
 
+def getSerpapiProviderConfig() -> str:
+    SerpapiConfig = namedtuple(
+        'SerpapiConfig',
+        [
+            'serpapi_api_key',
+        ]
+    )
+    if not (serpapi_api_key := os.getenv('SERPAPI_API_KEY')):
+        return None
+
+    return SerpapiConfig(
+        serpapi_api_key=serpapi_api_key
+    )
+
+
 def getOpenaiProviderConfig() -> dict:
     OpenaiConfig = namedtuple(
         'OpenaiConfig',
@@ -81,6 +96,14 @@ def getProviderConfig(provider_name: str) -> dict:
             return getPalmProviderConfig()
 
 
+def getToolsConfig() -> dict:
+    supported_tools = ('serpapi')
+
+    return {
+        'serpapi': getSerpapiProviderConfig(),
+    }
+
+
 # Get configurations
 load_dotenv(find_dotenv())
 specs_file = os.getenv('SPECS') or 'specs.md'  # defaults to specs.md
@@ -88,3 +111,4 @@ output_file = os.getenv('OUTPUT_FILE') or 'output.md'  # defaults to output.md
 retries = int(os.getenv('MAX_RETRIES', 3) or 3)  # defaults to 3
 provider = os.getenv('PROVIDER') or 'openai'  # defaults to openai
 provider_config = getProviderConfig(provider_name=provider)
+tools_config = getToolsConfig()

--- a/models.py
+++ b/models.py
@@ -4,6 +4,7 @@ from langchain.embeddings import OpenAIEmbeddings, VertexAIEmbeddings
 from config import retries
 from config import provider_config as cfg
 
+
 def get_provider_model():
     llm = None
     # OpenAI
@@ -22,7 +23,9 @@ def get_provider_model():
                 openai_api_key=cfg.api_key,
                 max_retries=retries,
             )
-        embeddings = OpenAIEmbeddings()
+        embeddings = OpenAIEmbeddings(
+            openai_api_key=cfg.api_key,
+        )
 
     # Azure OpenAI
     if cfg.provider == "azure":
@@ -48,7 +51,9 @@ def get_provider_model():
                 max_retries=retries,
                 openai_api_type="azure",
             )
-        embeddings = OpenAIEmbeddings()
+        embeddings = OpenAIEmbeddings(
+            openai_api_key=cfg.api_key,
+        )
 
     # Google Vertex AI (PaLM)
     if cfg.provider == "palm":
@@ -65,6 +70,6 @@ def get_provider_model():
                 model_name=cfg.model_name,
                 location=cfg.location,
                 max_output_tokens=1024,
-            )    
-        embeddings = VertexAIEmbeddings()    
+            )
+        embeddings = VertexAIEmbeddings()
     return llm, embeddings


### PR DESCRIPTION
# Changes

- Adds `tools_config`. Previously, only providers had config.
- Refactors each tool definition so it is appended to `tools_list` as needed, and possibly after some input validation.
- SerpApi Api Key is now optional depending on whether `SERPAPI_API_KEY` is defined.
- Adds `openai_api_key` to `OpenAIEmbeddings()`
